### PR TITLE
Set site.url again

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ encoding: UTF-8
 email: jon@thesquareplanet.com
 description: >
   PhD Student, Software Engineer and problem solver
+url: "https://thesquareplanet.com"
 permalink: /blog/:title/
 include: [".well-known"]
 kramdown:

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,11 +12,11 @@
   <meta name="twitter:site" content="@jonhoo" />
   <meta name="twitter:creator" content="@jonhoo" />
   {% if page.layout == "post" %}
-  <meta property="og:url" content="{{ site.url }}{{ page.url }}" />
+  <meta property="og:url" content="{{ page.url | absolute_url }}" />
   <meta property="og:title" content="{{ page.title | strip_html | strip_newlines | xml_escape }}" />
   <meta property="og:description" content="{{ page.excerpt | strip_html | xml_escape }}" />
   {% endif %}
   <link rel="stylesheet" href="/css/style.css">
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
+  <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="/feed.xml">
 </head>

--- a/feed.xml
+++ b/feed.xml
@@ -17,7 +17,7 @@ layout: null
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-	<link>{{ site.url }}{{ post.url }}</link>
+	<link>{{ post.url | absolute_url }}</link>
 	<guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
         {% for tag in post.tags %}
         <category>{{ tag | xml_escape }}</category>


### PR DESCRIPTION
It's no longer set automatically by GitHub Pages, so all these links have ended up (erroneously) being relative!

For local development, the value ends up being `localhost:4000` (or whatever `jekyll serve` does) anyway, so this doesn't break local use.

See also https://mademistakes.com/mastering-jekyll/site-url-baseurl/.

Effectively reverts 9223034d8e4679eb3260d865fa774521d4054c07.